### PR TITLE
Add try/except to rerun().

### DIFF
--- a/pyppeteer/frame_manager.py
+++ b/pyppeteer/frame_manager.py
@@ -883,10 +883,16 @@ class WaitTask(object):
                 await success.dispose()
             return
 
-        if not error and success and (
-                await self._frame.evaluate('s => !s', success)):
+        # Add try/except referring to puppeteer.
+        try:
+            if not error and success and (
+                    await self._frame.evaluate('s => !s', success)):
+                await success.dispose()
+                return
+        except NetworkError:
             await success.dispose()
             return
+
 
         # page is navigated and context is destroyed.
         # Try again in the new execution context.


### PR DESCRIPTION
Add try/except referring to puppeteer.
If you don't try, NetworkError frequently occurs.